### PR TITLE
fix: correct date-range filter in casual payout aggregation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,3 @@
-
 name: CI
 
 on:
@@ -29,21 +28,21 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11.9'
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 18
           check-latest: true
 
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py', '**/setup.cfg') }}
@@ -53,9 +52,9 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: 'echo "::set-output name=dir::$(yarn cache dir)"'
+        run: 'echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -66,7 +65,7 @@ jobs:
       - name: Setup
         run: |
           pip install frappe-bench
-          bench init --skip-redis-config-generation --skip-assets --python "$(which python)" ~/frappe-bench
+          bench init --skip-redis-config-generation --skip-assets --frappe-branch version-15 --python "$(which python)" ~/frappe-bench
           mysql --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
           mysql --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,13 @@ jobs:
         working-directory: /home/runner/frappe-bench
         run: |
           bench get-app --branch version-15 --skip-assets erpnext
+          bench get-app --branch version-15 --skip-assets payments
           bench get-app --branch version-15 --skip-assets hrms
           bench get-app --skip-assets nl_piece_rate_pay $GITHUB_WORKSPACE
           bench setup requirements --dev
           bench new-site --db-root-password root --admin-password admin test_site
           bench --site test_site install-app erpnext
+          bench --site test_site install-app payments
           bench --site test_site install-app hrms
           bench --site test_site install-app nl_piece_rate_pay
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,18 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
 
+      redis-cache:
+        image: redis:6.2-alpine
+        ports:
+          - 13000:6379
+        options: --health-cmd="redis-cli ping" --health-interval=5s --health-timeout=2s --health-retries=5
+
+      redis-queue:
+        image: redis:6.2-alpine
+        ports:
+          - 11000:6379
+        options: --health-cmd="redis-cli ping" --health-interval=5s --health-timeout=2s --health-retries=5
+
     steps:
       - name: Clone
         uses: actions/checkout@v4
@@ -72,15 +84,14 @@ jobs:
       - name: Install
         working-directory: /home/runner/frappe-bench
         run: |
-          bench get-app --branch version-15 erpnext
-          bench get-app --branch version-15 hrms
-          bench get-app nl_piece_rate_pay $GITHUB_WORKSPACE
+          bench get-app --branch version-15 --skip-assets erpnext
+          bench get-app --branch version-15 --skip-assets hrms
+          bench get-app --skip-assets nl_piece_rate_pay $GITHUB_WORKSPACE
           bench setup requirements --dev
           bench new-site --db-root-password root --admin-password admin test_site
           bench --site test_site install-app erpnext
           bench --site test_site install-app hrms
           bench --site test_site install-app nl_piece_rate_pay
-          bench build
         env:
           CI: 'Yes'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
         working-directory: /home/runner/frappe-bench
         run: |
           bench --site test_site set-config allow_tests true
+          bench --site test_site execute erpnext.setup.utils.before_tests
           bench --site test_site run-tests --app nl_piece_rate_pay
         env:
           TYPE: server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,21 +29,21 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.10'
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14
           check-latest: true
 
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py', '**/setup.cfg') }}
@@ -55,7 +55,7 @@ jobs:
         id: yarn-cache-dir-path
         run: 'echo "::set-output name=dir::$(yarn cache dir)"'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,13 @@ jobs:
       - name: Install
         working-directory: /home/runner/frappe-bench
         run: |
+          bench get-app --branch version-15 erpnext
+          bench get-app --branch version-15 hrms
           bench get-app nl_piece_rate_pay $GITHUB_WORKSPACE
           bench setup requirements --dev
           bench new-site --db-root-password root --admin-password admin test_site
+          bench --site test_site install-app erpnext
+          bench --site test_site install-app hrms
           bench --site test_site install-app nl_piece_rate_pay
           bench build
         env:

--- a/nl_piece_rate_pay/nl_piece_rate_pay/doctype/casual_salary_structure_assignment_tool/casual_salary_structure_assignment_tool.py
+++ b/nl_piece_rate_pay/nl_piece_rate_pay/doctype/casual_salary_structure_assignment_tool/casual_salary_structure_assignment_tool.py
@@ -18,9 +18,8 @@ class CasualSalaryStructureAssignmentTool(Document):
 			salary_structure_assignment.save()
    
 	def on_cancel(self):
-		casual_payout_list=casual_payout_list = frappe.get_all("Casual Payroll Payout",  filters={
-											"attendance_date": (">=", self.start_date),
-											"attendance_date": ("<=", self.end_date),
+		casual_payout_list = frappe.get_all("Casual Payroll Payout",  filters={
+											"attendance_date": ["between", [self.start_date, self.end_date]],
 											"docstatus":1,
 											"payment_processed":1
 										},fields=["name"])
@@ -38,8 +37,7 @@ def get_employees_calculate_weekly_pay():
 
 # Retrieve all Casual Payroll Payout documents within the specified date range
 	casual_payout_list = frappe.get_all("Casual Payroll Payout",  filters={
-											"attendance_date": (">=", start_date),
-											"attendance_date": ("<=", end_date),
+											"attendance_date": ["between", [start_date, end_date]],
 											"docstatus":1,
 											"payment_processed":0
 										},fields=["name"])


### PR DESCRIPTION
The attendance_date range filter in the Casual Salary Structure Assignment Tool used a Python dict with "attendance_date" as a key twice once for the >= start bound and once for the <= end bound. Because a dict can't hold duplicate keys, the second entry overwrites the first, so only the end-date bound was ever applied.

Impact
The weekly roll-up (Calculate Payout) and the cancel-reversal both ignored the start date, pulling in any matching payout on or before the end date regardless of how far back it went. This could sweep older, unintended payouts into a pay period (or un-process them on cancel).

Fix
Replaced both filters with the inclusive ["between", [start_date, end_date]] operator, so both bounds apply as intended. Also removed a redundant double-assignment (x = x = ...) on the same line. No API changes, behaviour only fix.

Testing
Create payouts spanning dates inside and outside a target window, run Calculate Payout, and confirm only in-range payouts are aggregated; cancel the run and confirm only in-range payouts are reset to unprocessed.